### PR TITLE
Add 'describe' functionality for config keys

### DIFF
--- a/src/riak_cli.erl
+++ b/src/riak_cli.erl
@@ -38,7 +38,8 @@ register_usage(Cmd, Usage) ->
 %% @doc Take a status type and generate console output
 -spec print(err() | riak_cli_status:status()) -> ok.
 print({error, _}=E) ->
-    riak_cli_error:print(E);
+    Alert = riak_cli_error:format(E),
+    print(Alert);
 print(Status) ->
     Output = riak_cli_writer:write(Status),
     io:format("~s", [Output]),
@@ -47,9 +48,11 @@ print(Status) ->
 %% @doc Run a config operation or command
 -spec run([string()]) -> ok | {error, term()}.
 run([_Script, "set" | Args]) ->
-    riak_cli_config:set(Args);
+    print(riak_cli_config:set(Args));
 run([_Script, "show" | Args]) ->
     print(riak_cli_config:show(Args));
+run([_Script, "describe" | Args]) ->
+    print(riak_cli_config:describe(Args));
 run(Cmd0) ->
     case is_help(Cmd0) of
         {ok, Cmd} ->

--- a/src/riak_cli_command.erl
+++ b/src/riak_cli_command.erl
@@ -24,8 +24,7 @@ register(Cmd, Keys, Flags, Fun) ->
 -spec run(err()) -> err();
          ({fun(), proplist(), proplist()})-> ok | err().
 run({error, _}=E) ->
-    riak_cli_error:print(E),
-    E;
+    riak_cli_error:format(E);
 run({Fun, Args, Flags}) ->
     Fun(Args, Flags).
 

--- a/src/riak_cli_config.erl
+++ b/src/riak_cli_config.erl
@@ -261,18 +261,20 @@ get_valid_mappings(KeysAndFlags) ->
             end
     end.
 
--spec valid_mappings([string()], [tuple()]) -> [tuple()].
+-spec valid_mappings([cuttlefish_variable:variable()], [tuple()]) -> [tuple()].
 valid_mappings(Keys, Mappings) ->
     lists:filter(fun(Mapping) ->
                      Key = element(2, Mapping),
                      lists:member(Key, Keys)
                  end, Mappings).
 
+-spec invalid_keys([cuttlefish_variable:variable()],
+                   [cuttlefish_mapping:mapping()]) -> [string()].
 invalid_keys(Keys, Mappings) ->
     Invalid = lists:filter(fun(Key) ->
                                not lists:keymember(Key, 2, Mappings)
                            end, Keys),
-    [cuttlefish_variable:format(I)++" " || I <- Invalid].
+   [cuttlefish_variable:format(I)++" " || I <- Invalid].
 
 -spec get_env_keys(list(tuple())) -> [{atom(), atom()}].
 get_env_keys(Mappings) ->

--- a/src/riak_cli_error.erl
+++ b/src/riak_cli_error.erl
@@ -19,7 +19,7 @@ format({error, {invalid_flag, Str}}) ->
 format({error, {invalid_action, Str}}) ->
     status(io_lib:format("Invalid Action: ~p~n", [Str]));
 format({error, invalid_number_of_args}) ->
-    status(io_lib:format("Invalid number of arguments~n"));
+    status("Invalid number of arguments~n");
 format({error, {invalid_argument, Str}}) ->
     status(io_lib:format("Invalid argument: ~p~n", [Str]));
 format({error, {invalid_flags, Flags}}) ->

--- a/src/riak_cli_error.erl
+++ b/src/riak_cli_error.erl
@@ -1,39 +1,47 @@
 -module(riak_cli_error).
 
 %% API
--export([print/1]).
+-export([format/1]).
 
+-type status() :: riak_cli_status:status().
 -type err() :: {error, term()}.
 
--spec print(err()) -> ok.
-print({error, {no_matching_spec, Cmd}}) ->
+-spec format(err()) -> status().
+format({error, {no_matching_spec, Cmd}}) ->
     case riak_cli_usage:find(Cmd) of
         {error, _} ->
-            io:format("Invalid Command~n");
+            status("Invalid Command~n");
         Usage ->
-            io:format("~s", [Usage])
+            status(io_lib:format("~s", [Usage]))
     end;
-print({error, {invalid_flag, Str}}) ->
-    io:format("Invalid Flag: ~p~n", [Str]);
-print({error, {invalid_action, Str}}) ->
-    io:format("Invalid Action: ~p~n", [Str]);
-print({error, invalid_number_of_args}) ->
-    io:format("Invalid number of arguments~n");
-print({error, {invalid_argument, Str}}) ->
-    io:format("Invalid argument: ~p~n", [Str]);
-print({error, {invalid_flags, Flags}}) ->
-    io:format("Invalid Flags: ~p~n", [Flags]);
-print({error, {invalid_flag_value, {Name, Val}}}) ->
-    io:format("Invalid value: ~p for flag: ~p~n", [Val, Name]);
-print({error, {invalid_flag_combination, Msg}}) ->
-    io:format("Error: ~s~n", [Msg]);
-print({error, {invalid_value, Val}}) ->
-    io:format("Invalid value: ~p~n", [Val]);
-print({error, {invalid_kv_arg, Arg}}) ->
-    io:format("Not a Key/Value argument of format: ~p=<Value>: ~n", [Arg]);
-print({error, {too_many_equal_signs, Arg}}) ->
-    io:format("Too Many Equal Signs in Argument: ~p~n", [Arg]);
-print({error, {invalid_config_keys, Invalid}}) ->
-    io:format("Invalid Config Keys: ~p~n", [Invalid]);
-print({error, {invalid_config, Msg}}) ->
-    io:format("Invalid Configuration: ~p~n", [Msg]).
+format({error, {invalid_flag, Str}}) ->
+    status(io_lib:format("Invalid Flag: ~p~n", [Str]));
+format({error, {invalid_action, Str}}) ->
+    status(io_lib:format("Invalid Action: ~p~n", [Str]));
+format({error, invalid_number_of_args}) ->
+    status(io_lib:format("Invalid number of arguments~n"));
+format({error, {invalid_argument, Str}}) ->
+    status(io_lib:format("Invalid argument: ~p~n", [Str]));
+format({error, {invalid_flags, Flags}}) ->
+    status(io_lib:format("Invalid Flags: ~p~n", [Flags]));
+format({error, {invalid_flag_value, {Name, Val}}}) ->
+    status(io_lib:format("Invalid value: ~p for flag: ~p~n", [Val, Name]));
+format({error, {invalid_flag_combination, Msg}}) ->
+    status(io_lib:format("Error: ~s~n", [Msg]));
+format({error, {invalid_value, Val}}) ->
+    status(io_lib:format("Invalid value: ~p~n", [Val]));
+format({error, {invalid_kv_arg, Arg}}) ->
+    status(io_lib:format(
+        "Not a Key/Value argument of format: ~p=<Value>: ~n", [Arg]));
+format({error, {too_many_equal_signs, Arg}}) ->
+    status(io_lib:format("Too Many Equal Signs in Argument: ~p~n", [Arg]));
+format({error, {invalid_config_keys, Invalid}}) ->
+    status(io_lib:format("Invalid Config Keys: ~s~n", [Invalid]));
+format({error, config_no_args}) ->
+    status("Config Operations require one or more arguments.");
+format({error, {invalid_config, Msg}}) ->
+    status(io_lib:format("Invalid Configuration: ~p~n", [Msg])).
+
+-spec status(string()) -> status().
+status(Str) ->
+    [riak_cli_status:alert([riak_cli_status:text(Str)])].

--- a/src/riak_cli_status.erl
+++ b/src/riak_cli_status.erl
@@ -5,7 +5,8 @@
          text/1,
          column/2,
          table/1,
-         alert/1]).
+         alert/1,
+         is_status/1]).
 
 
 -include("riak_cli_status_types.hrl").
@@ -25,6 +26,19 @@ parse([{alert, Elem} | T], Fun, Acc) ->
 parse([Elem | T], Fun, Acc) ->
     Acc1 = Fun(Elem, Acc),
     parse(T, Fun, Acc1).
+
+%% @doc Is the given value a status type?
+-spec is_status(any()) -> boolean().
+is_status({text, _}) ->
+    true;
+is_status({column, _, _}) ->
+    true;
+is_status({table, _, _}) ->
+    true;
+is_status({alert, _}) ->
+    true;
+is_status(_) ->
+    false.
 
 -spec text(iolist()) -> text().
 text(IoList) ->


### PR DESCRIPTION
Running a command such as `riak-admin describe anti-entropy` will now
return the docstring in the cuttlefish schema. It can be use with 1
or more space separated keys.

Additionally make error handling match regular status and convert
errors to status alerts while displaying them using the console
writer.  `set`, `show` and `describe` now all show an alert when
called with no arguments.
