### PR TITLE
Add riak_cli_typecast moduled

### DIFF
--- a/src/riak_cli.erl
+++ b/src/riak_cli.erl
@@ -13,7 +13,7 @@
 
 -spec register([module()]) -> ok.
 register(Modules) ->
-    [M:register_cli() || M <- Modules],
+    _ = [M:register_cli() || M <- Modules],
     ok.
 
 %% @doc RPC calls when using the --all flag need a list of nodes to contact.

--- a/src/riak_cli_config.erl
+++ b/src/riak_cli_config.erl
@@ -209,8 +209,7 @@ set_local_app_config(AppConfig) ->
 set_remote_app_config(AppConfig, Node) ->
     Fun = set_local_app_config,
     case riak_cli_nodes:safe_rpc(Node, ?MODULE, Fun, [AppConfig]) of
-        {badrpc, rpc_process_down} ->
-            io:format("Error: Node ~p Down~n", [Node]),
+        {badrpc, _} ->
             ok;
         ok ->
             ok
@@ -231,7 +230,7 @@ set_remote_app_config(AppConfig) ->
 config_flags() ->
     [{node, [{shortname, "n"},
              {longname, "node"},
-             {typecast, fun list_to_atom/1},
+             {typecast, fun riak_cli_typecast:to_node/1},
              {description,
                  "The node to apply the operation on"}]},
 

--- a/src/riak_cli_error.erl
+++ b/src/riak_cli_error.erl
@@ -38,9 +38,11 @@ format({error, {too_many_equal_signs, Arg}}) ->
 format({error, {invalid_config_keys, Invalid}}) ->
     status(io_lib:format("Invalid Config Keys: ~s~n", [Invalid]));
 format({error, config_no_args}) ->
-    status("Config Operations require one or more arguments.");
+    status("Config Operations require one or more arguments");
 format({error, {invalid_config, Msg}}) ->
-    status(io_lib:format("Invalid Configuration: ~p~n", [Msg])).
+    status(io_lib:format("Invalid Configuration: ~p~n", [Msg]));
+format({error, bad_node}) ->
+    status("Invalid node name").
 
 -spec status(string()) -> status().
 status(Str) ->

--- a/src/riak_cli_typecast.erl
+++ b/src/riak_cli_typecast.erl
@@ -1,0 +1,13 @@
+-module(riak_cli_typecast).
+
+-export([to_node/1]).
+
+%% This typecast automatically checks if the node is in our cluster,
+%% since the atom will have to be registered
+-spec to_node(string()) -> node() | {error, bad_node}.
+to_node(Str) ->
+    try
+        list_to_existing_atom(Str)
+    catch error:badarg ->
+        {error, bad_node}
+    end.

--- a/src/riak_cli_typecast.erl
+++ b/src/riak_cli_typecast.erl
@@ -7,7 +7,13 @@
 -spec to_node(string()) -> node() | {error, bad_node}.
 to_node(Str) ->
     try
-        list_to_existing_atom(Str)
+        Node = list_to_existing_atom(Str),
+        case lists:member(Node, riak_cli_nodes:nodes()) of
+            true ->
+                Node;
+            false ->
+                {error, bad_node}
+        end
     catch error:badarg ->
         {error, bad_node}
     end.


### PR DESCRIPTION
This module exports common typecast functions. Additionally fix how bad
nodes are checked and fix dialyzer error.
