### PR TITLE
Change 'column' status type to 'list'

### DIFF
--- a/include/riak_cli_status_types.hrl
+++ b/include/riak_cli_status_types.hrl
@@ -4,8 +4,8 @@
 %% data structures and types and be able to generate human readable output, json,
 %% csv and a subset of html, as well as other possible output.
 -type text() :: {text, iolist()}.
--type column() :: {column, iolist(), [iolist()]}.
+-type status_list() :: {list, iolist(), [iolist()]} | {list, [iolist()]}.
 -type table() :: {table, [{iolist(), iolist()}]}.
--type alert() :: {alert, [column() | table() | text()]}.
--type elem() :: text() | column() | table() | alert().
+-type alert() :: {alert, [status_list() | table() | text()]}.
+-type elem() :: text() | status_list() | table() | alert().
 -type status() :: [elem()].

--- a/src/riak_cli_status.erl
+++ b/src/riak_cli_status.erl
@@ -22,7 +22,8 @@
 %% API
 -export([parse/3,
          text/1,
-         column/2,
+         list/1,
+         list/2,
          table/1,
          alert/1,
          is_status/1]).
@@ -47,9 +48,11 @@ parse([Elem | T], Fun, Acc) ->
 
 %% @doc Is the given value a status type?
 -spec is_status(any()) -> boolean().
+is_status(L) when is_list(L) ->
+    is_status(hd(L));
 is_status({text, _}) ->
     true;
-is_status({column, _, _}) ->
+is_status({list, _, _}) ->
     true;
 is_status({table, _, _}) ->
     true;
@@ -62,10 +65,13 @@ is_status(_) ->
 text(IoList) ->
     {text, IoList}.
 
-%% @doc A column has an attribute and a list of values for that attribute.
--spec column(iolist(), [iolist()]) -> column().
-column(Title, Values) ->
-    {column, Title, Values}.
+-spec list([iolist()]) -> status_list().
+list(Values) ->
+    {list, Values}.
+
+-spec list(iolist(), [iolist()]) -> status_list().
+list(Title, Values) ->
+    {list, Title, Values}.
 
 %% @doc A table is constructed from a list of proplists. Each proplist
 %% represents a row in the table. The keys in the first row represent
@@ -76,6 +82,6 @@ table(Proplists) ->
    {table, Proplists}.
 
 %% A list of elements
--spec alert([column() | table() | text()]) -> alert().
+-spec alert([status_list() | table() | text()]) -> alert().
 alert(List) ->
     {alert, List}.

--- a/src/riak_cli_writer.erl
+++ b/src/riak_cli_writer.erl
@@ -45,8 +45,10 @@ write_status(alert, Ctx) ->
     throw({error, nested_alert, Ctx});
 write_status(alert_done, Ctx) ->
     Ctx#context{alert_set=false};
-write_status({column, Title, Data}, Ctx=#context{output=Output}) ->
-    Ctx#context{output=Output++write_column(Title, Data)};
+write_status({list, Data}, Ctx=#context{output=Output}) ->
+    Ctx#context{output=Output++write_list(Data)};
+write_status({list, Title, Data}, Ctx=#context{output=Output}) ->
+    Ctx#context{output=Output++write_list(Title, Data)};
 write_status({text, Text}, Ctx=#context{output=Output}) ->
     Ctx#context{output=Output++Text++"\n"};
 write_status({table, Rows}, Ctx=#context{output=Output}) ->
@@ -63,16 +65,18 @@ write_table(Rows0) ->
     Table = riak_cli_table:autosize_create_table(Schema, Rows),
     io_lib:format("~ts~n", [Table]).
 
-%% @doc Write a column on a single line.
-write_column(Title, Items) when is_atom(Title) ->
-    write_column(atom_to_list(Title), Items);
+%% @doc Write a list horizontally
+write_list(Title, Items) when is_atom(Title) ->
+    write_list(atom_to_list(Title), Items);
 %% Assume all items are of same type
-write_column(Title, Items) when is_atom(hd(Items)) ->
+write_list(Title, Items) when is_atom(hd(Items)) ->
     Items2 = [atom_to_list(Item) || Item <- Items],
-    write_column(Title, Items2);
-write_column(Title, Items) ->
+    write_list(Title, Items2);
+write_list(Title, Items) ->
     %% Todo: add bold/color for Title when supported
+    Title ++ ":" ++ write_list(Items) ++ "\n".
+
+write_list(Items) ->
     lists:foldl(fun(Item, Acc) ->
                     Acc++" "++Item
-                end, Title++":", Items) ++ "\n".
-
+                end, "", Items).


### PR DESCRIPTION
Also create 2 list constructor functions. `list/2` does the same thing
as `column/2`. `list/1` creates a list without a title.

In addition, fix the `is_status/1` function so that a list of elements
is also status.
