### PR TITLE
Display config vals of type 'flag' correctly

### DIFF
--- a/src/clique_config.erl
+++ b/src/clique_config.erl
@@ -127,10 +127,10 @@ get_local_env_vals(AppKeyPairs, CuttlefishFlags) ->
     Vals = [begin
                 {ok, Val} = application:get_env(App, Key),
                 case {CFlagSpec, Val} of
-                    {{flag, FalseVal, _}, false} ->
-                        FalseVal;
-                    {{flag, _, TrueVal}, true} ->
+                    {{flag, TrueVal, _}, true} ->
                         TrueVal;
+                    {{flag, _, FalseVal}, false} ->
+                        FalseVal;
                     _ ->
                         Val
                 end
@@ -327,9 +327,9 @@ get_cuttlefish_flags(Mappings) ->
     NormalizeFlag = fun(M) ->
                             case cuttlefish_mapping:datatype(M) of
                                 [flag] ->
-                                    {flag, off, on};
-                                [{flag, FalseVal, TrueVal}] ->
-                                    {flag, FalseVal, TrueVal};
+                                    {flag, on, off};
+                                [{flag, TrueVal, FalseVal}] ->
+                                    {flag, TrueVal, FalseVal};
                                 _ ->
                                     undefined
                             end

--- a/src/clique_config.erl
+++ b/src/clique_config.erl
@@ -282,7 +282,7 @@ get_valid_mappings(KeysAndFlags) ->
 -spec valid_mappings([cuttlefish_variable:variable()], [tuple()]) -> [tuple()].
 valid_mappings(Keys, Mappings) ->
     lists:filter(fun(Mapping) ->
-                     Key = element(2, Mapping),
+                     Key = cuttlefish_mapping:variable(Mapping),
                      lists:member(Key, Keys)
                  end, Mappings).
 
@@ -296,7 +296,7 @@ invalid_keys(Keys, Mappings) ->
 
 -spec get_env_keys(list(tuple())) -> [{atom(), atom()}].
 get_env_keys(Mappings) ->
-    EnvStrs = [element(3, M) || M <- Mappings],
+    EnvStrs = [cuttlefish_mapping:mapping(M) || M <- Mappings],
     AppAndKeys = [string:tokens(S, ".") || S <- EnvStrs],
     [{list_to_atom(App), list_to_atom(Key)} || [App, Key] <-  AppAndKeys].
 

--- a/src/clique_config.erl
+++ b/src/clique_config.erl
@@ -259,7 +259,8 @@ config_flags() ->
                 "Apply the operation to all nodes in the cluster"}]}].
 
 
--spec get_valid_mappings([string()]) -> err() | {[string()], list(tuple()), flags()}.
+-spec get_valid_mappings([string()]) -> err() |
+                                        {[string()], [cuttlefish_mapping:mapping()], flags()}.
 get_valid_mappings(KeysAndFlags) ->
     {Keys0, Flags0} = lists:splitwith(fun clique_parser:is_not_flag/1, KeysAndFlags),
     Keys = [cuttlefish_variable:tokenize(K) || K <- Keys0],
@@ -294,7 +295,7 @@ invalid_keys(Keys, Mappings) ->
                            end, Keys),
    [cuttlefish_variable:format(I)++" " || I <- Invalid].
 
--spec get_env_keys(list(tuple())) -> [{atom(), atom()}].
+-spec get_env_keys([cuttlefish_mapping:mapping()]) -> [{atom(), atom()}].
 get_env_keys(Mappings) ->
     EnvStrs = [cuttlefish_mapping:mapping(M) || M <- Mappings],
     AppAndKeys = [string:tokens(S, ".") || S <- EnvStrs],


### PR DESCRIPTION
This fixes issue #20. When using the "show" command to display config values, we now display config values of type 'flag' using the correct user-facing values (typically "on" and "off") instead of the internal true/false value.

This PR also includes a couple of very minor commits to improve some code and type specs in the clique_config module.
