### PR TITLE
Print an error on "show" command sent to down node

### DIFF
--- a/src/clique_config.erl
+++ b/src/clique_config.erl
@@ -150,6 +150,8 @@ get_remote_env_status(Keys, AppKeyPairs, CuttlefishFlags, Node) ->
         {badrpc, rpc_process_down} ->
             io:format("Error: Node ~p Down~n", [Node]),
             [];
+        {badrpc, nodedown} ->
+            {error, {nodedown, Node}};
         Status ->
             Status
     end.

--- a/src/clique_error.erl
+++ b/src/clique_error.erl
@@ -69,6 +69,8 @@ format({error, {invalid_config, {error, [_H|_T]=Msgs}}}) ->
                                  Msgs), "\n"));
 format({error, {invalid_config, Msg}}) ->
     status(io_lib:format("Invalid Configuration: ~p~n", [Msg]));
+format({error, {nodedown, Node}}) ->
+    status(io_lib:format("Target node is down: ~p~n", [Node]));
 format({error, bad_node}) ->
     status("Invalid node name").
 


### PR DESCRIPTION
Previously, running the "show" command and using the -n flag to specify
a node that's down would have yielded a crash dump. It now prints a
simple error message instead.

This resolves issue #28.
