### PR TITLE
Improve error reporting for set/show

### DIFF
--- a/src/clique_config.erl
+++ b/src/clique_config.erl
@@ -149,8 +149,7 @@ get_remote_env_status(EnvKeys, CuttlefishFlags, Node) ->
     case clique_nodes:safe_rpc(Node, ?MODULE, get_local_env_status,
                                [EnvKeys, CuttlefishFlags]) of
         {badrpc, rpc_process_down} ->
-            io:format("Error: Node ~p Down~n", [Node]),
-            [];
+            {error, {rpc_process_down, Node}};
         {badrpc, nodedown} ->
             {error, {nodedown, Node}};
         Status ->
@@ -247,8 +246,10 @@ set_local_app_config(AppConfig) ->
 set_remote_app_config(AppConfig, Node) ->
     Fun = set_local_app_config,
     case clique_nodes:safe_rpc(Node, ?MODULE, Fun, [AppConfig]) of
-        {badrpc, _} ->
-            ok;
+        {badrpc, rpc_process_down} ->
+            {error, {rpc_process_down, Node}};
+        {badrpc, nodedown} ->
+            {error, {nodedown, Node}};
         ok ->
             ok
     end.

--- a/src/clique_error.erl
+++ b/src/clique_error.erl
@@ -69,6 +69,8 @@ format({error, {invalid_config, {error, [_H|_T]=Msgs}}}) ->
                                  Msgs), "\n"));
 format({error, {invalid_config, Msg}}) ->
     status(io_lib:format("Invalid Configuration: ~p~n", [Msg]));
+format({error, {rpc_process_down, Node}}) ->
+    status(io_lib:format("Target process could not be reached on node: ~p~n", [Node]));
 format({error, {nodedown, Node}}) ->
     status(io_lib:format("Target node is down: ~p~n", [Node]));
 format({error, bad_node}) ->


### PR DESCRIPTION
Previously we didn't report any RPC errors for the "set" command. This commit fixes that problem, and also tweaks the error reporting for the "show" command to follow a more consistent pattern with the rest of clique.

This fixes issue #32.
