### PR TITLE
Add config formatter support to clique

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,29 @@ Callback = fun set_transfer_limit/3,
 clique:register_config(Key, Callback).
 ```
 
+### register_config_formatter/2
+By default, the clique "show" command displays the underlying config value, as stored in the
+corresponding application env variable (the one exception being values of type "flag", which are
+automatically displayed by clique as the user-facing flag value defined in the cuttlefish schema).
+In many cases this is fine, but sometimes there may be translations defined in the cuttlefish schema
+which make it desirable to show config values in a different format than the one used by the
+underlying Erlang code.
+
+To show a specific config value using a different format than the underlying raw application
+config, you can register a config formatter against that value's config key:
+
+```erlang
+F = fun(Val) ->
+        case Val of
+            riak_kv_bitcask_backend -> bitcask;
+            riak_kv_eleveldb_backend -> leveldb;
+            riak_kv_memory_backend -> memory;
+            riak_kv_multi_backend -> multi
+        end
+    end,
+clique:register_config_formatter(["storage_backend"], F).
+```
+
 ### register_config_whitelist/1
 A lot of configuration variables are not intended to be set at runtime. In order to prevent the user
 from changing them and anticipating the system to use the new values, we don't allow setting of any

--- a/src/clique.erl
+++ b/src/clique.erl
@@ -24,6 +24,7 @@
          register_node_finder/1,
          register_command/4,
          register_config/2,
+         register_formatter/2,
          register_config_whitelist/1,
          register_usage/2,
          run/1,
@@ -49,6 +50,11 @@ register_node_finder(Fun) ->
 -spec register_config([string()], fun()) -> true.
 register_config(Key, Callback) ->
     clique_config:register(Key, Callback).
+
+%% @doc Register a configuration formatter for a given config key
+-spec register_formatter([string()], fun()) -> true.
+register_formatter(Key, Callback) ->
+    clique_config:register_formatter(Key, Callback).
 
 %% @doc Register a list of configuration variables that are settable.
 %% Clique disallows setting of all config variables by default. They must be in

--- a/src/clique_config.erl
+++ b/src/clique_config.erl
@@ -363,7 +363,8 @@ get_valid_mappings(KeysAndFlags) ->
             end
     end.
 
--spec valid_mappings([cuttlefish_variable:variable()], [tuple()]) -> [tuple()].
+-spec valid_mappings([cuttlefish_variable:variable()], [cuttlefish_mapping:mapping()]) ->
+    [{string(), cuttlefish_mapping:mapping()}].
 valid_mappings(Keys, Mappings) ->
     lists:foldl(fun(Mapping, Acc) ->
                     Key = cuttlefish_mapping:variable(Mapping),

--- a/src/clique_config.erl
+++ b/src/clique_config.erl
@@ -22,6 +22,7 @@
 %% API
 -export([init/0,
          register/2,
+         register_formatter/2,
          show/1,
          set/1,
          whitelist/1,
@@ -36,6 +37,7 @@
 -define(config_table, clique_config).
 -define(schema_table, clique_schema).
 -define(whitelist_table, clique_whitelist).
+-define(formatter_table, clique_formatter).
 
 -type err() :: {error, term()}.
 -type status() :: clique_status:status().
@@ -51,10 +53,16 @@
 register(Key, Callback) ->
     ets:insert(?config_table, {Key, Callback}).
 
+%% @doc Register a pretty-print function for a given config key
+-spec register_formatter([string()], fun()) -> true.
+register_formatter(Key, Callback) ->
+    ets:insert(?formatter_table, {Key, Callback}).
+
 init() ->
     _ = ets:new(?config_table, [public, named_table]),
     _ = ets:new(?schema_table, [public, named_table]),
     _ = ets:new(?whitelist_table, [public, named_table]),
+    _ = ets:new(?formatter_table, [public, named_table]),
     ok.
 
 %% @doc Load Schemas into ets when given directories containing the *.schema files.
@@ -78,14 +86,6 @@ schema_paths(Directories) ->
                     Files ++ Acc
                 end, [], Directories).
 
-%% TODO: This doesn't work for keys with translations.
-%% This should almost certainly show the riak.conf value.
-%% But, there's not currently any way to reverse cuttlefish
-%% translations to get from the application env value back
-%% to the value you'd see in the config file or use with
-%% the "set" command. We do support flags because those are
-%% reversible, but to fully support all possible values we'll
-%% have to add reverse translation support to cuttlefish.
 -spec show([string()]) -> clique_status:status() | err().
 show(KeysAndFlags) ->
     case get_valid_mappings(KeysAndFlags) of
@@ -180,14 +180,22 @@ get_local_env_status(EnvKeys, CuttlefishFlags) ->
 get_local_env_vals(EnvKeys, CuttlefishFlags) ->
     Vals = [begin
                 {ok, Val} = application:get_env(App, Key),
-                case {CFlagSpec, Val} of
-                    {{flag, TrueVal, _}, true} ->
-                        {KeyStr, TrueVal};
-                    {{flag, _, FalseVal}, false} ->
-                        {KeyStr, FalseVal};
-                    _ ->
-                        {KeyStr, Val}
-                end
+                Val1 = case {CFlagSpec, Val} of
+                           {{flag, TrueVal, _}, true} ->
+                               TrueVal;
+                           {{flag, _, FalseVal}, false} ->
+                               FalseVal;
+                           _ ->
+                               Val
+                       end,
+                FormatterKey = cuttlefish_variable:tokenize(KeyStr),
+                Val2 = case ets:lookup(?formatter_table, FormatterKey) of
+                           [] ->
+                               Val1;
+                           [{_K, FormatterFun}] ->
+                               FormatterFun(Val1)
+                       end,
+                {KeyStr, Val2}
             end || {{KeyStr, {App, Key}}, CFlagSpec} <- lists:zip(EnvKeys, CuttlefishFlags)],
     [{"node", node()} | Vals].
 


### PR DESCRIPTION
This adds a new feature to clique whereby formatter functions can be registered to control how different config values are displayed via the "show" command. This is sometimes useful if the user-facing config value defined by cuttlefish is subjected to a translation, yielding a resulting value which makes sense to the underlying Erlang code, but may be confusing to the end user. By registering a config formatter for that config, the underlying value can be translated back into a user-friendly value for display purposes.

This allows us to address the problems described in issue #1.
