### PR TITLE
Add CSV formatter and support for other custom formats in general

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Clique provides the application developer with the following capabilities:
    configuration across one or all nodes: i.e.  `riak-admin set anti-entropy=on --all`
  * Return a standard status format that allows output of a variety of content
    types: human-readable, csv, html, etc... (Note that currently only
-   human-readable output is implemented)
+   human-readable and CSV output formats are implemented)
 
 ### Why Not Clique ?
  * You aren't writing a CLI
@@ -308,6 +308,19 @@ clique:register_usage(["riak-admin", "handoff"], handoff_usage()),
 %% Register a callback for dynamic output:
 clique:register_usage(["riak-admin", "handoff", "limit"], fun handoff_limit_usage/0).
 ```
+
+### register_writer/2
+This is not something most applications will likely need to use, but the
+capability exists to create custom output writer modules. Currently you can
+specify the `--format=[human|csv]` flag on many commands to determine how the
+output will be written; registering a new writer "foo" allows you to use
+`--format=foo` to write the output using whatever corresponding writer module
+you've registered.
+
+Writing custom output writers is relatively undocumented right now, and the
+values passed to the `write/1` callback may be subject to future changes. But,
+the `clique_*_writer` modules in the clique source tree provide good examples
+that can be used for reference.
 
 ### run/1
 `run/1` takes a given command as a list of strings and attempts to run the

--- a/include/clique_status_types.hrl
+++ b/include/clique_status_types.hrl
@@ -5,7 +5,7 @@
 %% csv and a subset of html, as well as other possible output.
 -type text() :: {text, iolist()}.
 -type status_list() :: {list, iolist(), [iolist()]} | {list, [iolist()]}.
--type table() :: {table, [{iolist(), iolist()}]}.
+-type table() :: {table, [[{atom() | string(), term()}]]}.
 -type alert() :: {alert, [status_list() | table() | text()]}.
 -type usage() :: usage.
 -type elem() :: text() | status_list() | table() | alert() | usage().

--- a/rebar.config
+++ b/rebar.config
@@ -6,6 +6,11 @@
 {xref_checks, []}.
 {xref_queries, [{"(XC - UC) || (XU - X - B - \"(cluster_info|dtrace)\" : Mod)", []}]}.
 
+{erl_first_files, [
+  "src/clique_writer.erl",
+  "src/clique_handler.erl"
+]}.
+
 {deps, [
   {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "2.0"}}}
 ]}.

--- a/src/clique.erl
+++ b/src/clique.erl
@@ -97,10 +97,6 @@ print(Status, _Cmd, Format) ->
 
 %% @doc Run a config operation or command
 -spec run([string()]) -> ok | {error, term()}.
-run([_Script, "show" | Args] = Cmd) ->
-    print(clique_config:show(Args), Cmd);
-run([_Script, "describe" | Args] = Cmd) ->
-    print(clique_config:describe(Args), Cmd);
 run(Cmd0) ->
     {GlobalFlags, Cmd} = extract_global_flags(Cmd0),
     case proplists:get_bool(help, GlobalFlags) of

--- a/src/clique.erl
+++ b/src/clique.erl
@@ -97,8 +97,6 @@ print(Status, _Cmd, Format) ->
 
 %% @doc Run a config operation or command
 -spec run([string()]) -> ok | {error, term()}.
-run([_Script, "set" | Args] = Cmd) ->
-    print(clique_config:set(Args), Cmd);
 run([_Script, "show" | Args] = Cmd) ->
     print(clique_config:show(Args), Cmd);
 run([_Script, "describe" | Args] = Cmd) ->

--- a/src/clique_command.erl
+++ b/src/clique_command.erl
@@ -47,8 +47,15 @@ register(Cmd, Keys, Flags, Fun) ->
          ({fun(), proplist(), proplist()})-> status().
 run({error, _}=E) ->
     E;
-run({Fun, Args, Flags}) ->
-    Fun(Args, Flags).
+run({Fun, Args, Flags, GlobalFlags}) ->
+    Format = proplists:get_value(format, GlobalFlags, "human"),
+    case proplists:is_defined(help, GlobalFlags) of
+        true ->
+            {usage, Format};
+        false ->
+            Result = Fun(Args, Flags),
+            {Result, Format}
+    end.
 
 -spec match([list()])-> {tuple(), list()} | {error, no_matching_spec}.
 match(Cmd0) ->

--- a/src/clique_csv_writer.erl
+++ b/src/clique_csv_writer.erl
@@ -72,7 +72,9 @@ format_val(V) when is_integer(V) ->
 format_val(V) when is_binary(V) ->
     format_val(unicode:characters_to_list(V, utf8));
 format_val(Str0) when is_list(Str0) ->
-    Str = string:strip(Str0),
+    %% TODO: This could probably be done more efficiently.
+    %% Maybe we could write a strip func that works directly on iolists?
+    Str = string:strip(binary_to_list(iolist_to_binary(Str0))),
     %% If we have any line breaks, double quotes, or commas, we must surround the value with
     %% double quotes.
     IsEvilChar = fun(C) -> lists:member(C, [$\r, $\n, $", $,]) end,

--- a/src/clique_csv_writer.erl
+++ b/src/clique_csv_writer.erl
@@ -1,0 +1,90 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(clique_csv_writer).
+
+%% @doc Implements a writer module for clique which outputs tabular data in CSV format.
+
+-behavior(clique_writer).
+
+-export([
+         write/1,
+         write_status/2
+        ]).
+
+-include("clique_status_types.hrl").
+
+-spec write(status()) -> iolist().
+write(Status) ->
+    Output = clique_status:parse(Status, fun write_status/2, []),
+    lists:reverse(Output).
+
+%% @doc Write status information in csv format.
+%%
+%% Anything other than a table is discarded, since there's no good way to represent non-tabular
+%% data in CSV. We want to be able to use the CSV output directly without needing to strip
+%% off any extranious stuff.
+-spec write_status(elem(), iolist()) -> iolist().
+write_status({table, Rows}, Output) ->
+    [write_table(Rows) | Output];
+write_status(_, Output) ->
+    Output.
+
+write_table([]) ->
+    "";
+write_table(Rows0) ->
+    Schema = [Name || {Name, _Val} <- hd(Rows0)],
+    Header = write_header(Schema),
+    Rows = write_rows([[Val || {_Name, Val} <- Row] || Row <- Rows0]),
+    [Header, Rows].
+
+write_header(Schema) ->
+    HeaderStrs = [format_val(Name) || Name <- Schema],
+    [string:join(HeaderStrs, ","), "\r\n"].
+
+write_rows(Rows) ->
+    [write_row(R) || R <- Rows].
+
+write_row(Row) ->
+    ValStrs = [format_val(V) || V <- Row],
+    [string:join(ValStrs, ","), "\r\n"].
+
+format_val(V) when is_atom(V) ->
+    format_val(atom_to_list(V));
+format_val(V) when is_integer(V) ->
+    format_val(integer_to_list(V));
+format_val(V) when is_binary(V) ->
+    format_val(unicode:characters_to_list(V, utf8));
+format_val(Str0) when is_list(Str0) ->
+    Str = string:strip(Str0),
+    %% If we have any line breaks, double quotes, or commas, we must surround the value with
+    %% double quotes.
+    IsEvilChar = fun(C) -> lists:member(C, [$\r, $\n, $", $,]) end,
+    case lists:any(IsEvilChar, Str) of
+        true ->
+            [$", escape(Str), $"];
+        false ->
+            Str
+    end.
+
+escape(Str) ->
+    %% According to RFC 4180, any double quote chars in quoted fields
+    %% should be escaped with extra double quotes. e.g. "aaa","b""bb","ccc"
+    SplitStr = string:tokens(Str, "\""),
+    string:join(SplitStr, "\"\"").

--- a/src/clique_error.erl
+++ b/src/clique_error.erl
@@ -27,11 +27,12 @@
 
 -spec format(string(), err()) -> status().
 format(Cmd, {error, show_no_args}) ->
-    status(io_lib:format("Usage: ~ts show <variable> ...", [Cmd]));
+    status(io_lib:format("Usage: ~ts show <variable> ... [[--node | -n] <node> | --all]", [Cmd]));
 format(Cmd, {error, describe_no_args}) ->
     status(io_lib:format("Usage: ~ts describe <variable> ...", [Cmd]));
 format(Cmd, {error, set_no_args}) ->
-    status(io_lib:format("Usage: ~ts set <variable>=<value> ...", [Cmd]));
+    status(io_lib:format("Usage: ~ts set <variable>=<value> ... [[--node | -n] <node> | --all]",
+                         [Cmd]));
 format(_Cmd, {error, {no_matching_spec, Cmd}}) ->
     case clique_usage:find(Cmd) of
         {error, _} ->
@@ -60,9 +61,6 @@ format(_Cmd, {error, {invalid_flag_combination, Msg}}) ->
     status(io_lib:format("Error: ~ts", [Msg]));
 format(_Cmd, {error, {invalid_value, Val}}) ->
     status(io_lib:format("Invalid value: ~p", [Val]));
-format(Cmd, {error, {invalid_kv_arg, Arg}}) ->
-    status(io_lib:format(
-             "Usage: ~ts set ~ts=<value> ...", [Cmd, Arg]));
 format(_Cmd, {error, {too_many_equal_signs, Arg}}) ->
     status(io_lib:format("Too many equal signs in argument: ~p", [Arg]));
 format(_Cmd, {error, {invalid_config_keys, Invalid}}) ->

--- a/src/clique_human_writer.erl
+++ b/src/clique_human_writer.erl
@@ -23,6 +23,8 @@
 %% clique_status:parse/3. It specifically formats the output for a human at the
 %% console and handles an opaque context passed back during parsing.
 
+-behavior(clique_writer).
+
 %% API
 -export([write/1]).
 

--- a/src/clique_manager.erl
+++ b/src/clique_manager.erl
@@ -42,6 +42,7 @@ start_link() ->
 %% messages, it can only die if explicitly killed.
 %%
 init([]) ->
+    ok = clique_writer:init(),
     ok = clique_command:init(),
     ok = clique_usage:init(),
     ok = clique_config:init(),

--- a/src/clique_parser.erl
+++ b/src/clique_parser.erl
@@ -33,7 +33,7 @@
 
 %% TODO: A spec should probably just be a record
 -type spec() :: {atom(), proplist()}.
--type keyspecs() :: [spec()].
+-type keyspecs() :: '_' | [spec()].
 -type flagspecs() :: [spec()].
 
 -spec parse(err()) -> err();
@@ -134,12 +134,12 @@ validate({Spec, Args0, Flags0}) ->
     end.
 
 -spec validate_args(keyspecs(), proplist()) -> err() | proplist().
+validate_args('_', Args) ->
+    Args;
 validate_args(KeySpecs, Args) ->
     convert_args(KeySpecs, Args, []).
 
 -spec convert_args(keyspecs(), proplist(), proplist()) -> err() | proplist().
-convert_args([], [], Acc) ->
-    Acc;
 convert_args(_KeySpec, [], Acc) ->
     Acc;
 convert_args([], Args, _Acc) ->
@@ -171,8 +171,6 @@ validate_flags(FlagSpecs, Flags) ->
     convert_flags(FlagSpecs, Flags, []).
 
 -spec convert_flags(flagspecs(), proplist(), flags()) -> err() | flags().
-convert_flags([], [], Acc) ->
-    Acc;
 convert_flags(_FlagSpecs, [], Acc) ->
     Acc;
 convert_flags([], Provided, _Acc) ->

--- a/src/clique_parser.erl
+++ b/src/clique_parser.erl
@@ -77,8 +77,6 @@ parse_kv_args([Arg | Args], Acc) ->
     case string:tokens(Arg, "=") of
         [Key, Val] ->
             parse_kv_args(Args, [{list_to_atom(Key), Val} | Acc]);
-        [Key] ->
-            {error, {invalid_kv_arg, Key}};
         _ ->
             {error, {too_many_equal_signs, Arg}}
     end.

--- a/src/clique_usage.erl
+++ b/src/clique_usage.erl
@@ -47,6 +47,15 @@ register(Cmd, Usage) ->
     ets:insert(?usage_table, {Cmd, Usage}).
 
 -spec print(iolist()) -> ok.
+print(Cmd = [Script, "describe" | _]) ->
+    Usage = clique_error:format(Script, {error, describe_no_args}),
+    clique:print(Usage, Cmd);
+print(Cmd = [Script, "show" | _]) ->
+    Usage = clique_error:format(Script, {error, show_no_args}),
+    clique:print(Usage, Cmd);
+print(Cmd = [Script, "set" | _]) ->
+    Usage = clique_error:format(Script, {error, set_no_args}),
+    clique:print(Usage, Cmd);
 print(Cmd) ->
     Usage = case find(Cmd) of
                 {error, Error} ->

--- a/src/clique_writer.erl
+++ b/src/clique_writer.erl
@@ -22,7 +22,10 @@
 
 -define(writer_table, clique_writers).
 
--define(BUILTIN_WRITERS, [{"human", clique_human_writer}]).
+-define(BUILTIN_WRITERS, [
+                          {"human", clique_human_writer},
+                          {"csv", clique_csv_writer}
+                         ]).
 
 -export([
          init/0,

--- a/src/clique_writer.erl
+++ b/src/clique_writer.erl
@@ -1,0 +1,63 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(clique_writer).
+
+-define(writer_table, clique_writers).
+
+-define(BUILTIN_WRITERS, [{"human", clique_human_writer}]).
+
+-export([
+         init/0,
+         register/2,
+         write/2
+        ]).
+
+%% @doc This module provides a central place to register different output writers
+%% with clique (e.g. human-readable, CSV, etc.)
+%% There are some built in, but we also allow applications to register their
+%% own custom writers if they so choose.
+
+-include("clique_status_types.hrl").
+
+%% TODO factor err type out into single clique:err() type - DRY!
+-type err() :: {error, term()}.
+
+-callback write(status()) -> iolist().
+
+-spec init() -> ok.
+init() ->
+    _ = ets:new(?writer_table, [public, named_table]),
+    ets:insert(?writer_table, ?BUILTIN_WRITERS),
+    ok.
+
+-spec register(string(), module()) -> true.
+register(Name, Module) ->
+    ets:insert(?writer_table, {Name, Module}).
+
+-spec write(err() | clique_status:status(), string()) -> iolist().
+write(Status, Format) ->
+    case ets:lookup(?writer_table, Format) of
+        [{Format, Module}] ->
+            Module:write(Status);
+        [] ->
+            io:format("Invalid format ~p! Defaulting to human-readable:~n", [Format]),
+            clique_human_writer:write(Status)
+    end.

--- a/src/clique_writer.erl
+++ b/src/clique_writer.erl
@@ -61,6 +61,7 @@ write(Status, Format) ->
         [{Format, Module}] ->
             Module:write(Status);
         [] ->
-            io:format("Invalid format ~p! Defaulting to human-readable:~n", [Format]),
-            clique_human_writer:write(Status)
+            Error = io_lib:format("Invalid format ~p! Defaulted to human-readable.~n", [Format]),
+            Output = clique_human_writer:write(Status),
+            [Output, "\n", Error]
     end.


### PR DESCRIPTION
This PR adds support for the --format global flag. With these changes we can specify --format=human or --format=csv. We also allow for easily adding more builtin formats in the future, or for registering formats at runtime using the clique:register_writer/2 API call.

This fixes issue #16.
