### PR TITLE
Don't allow columns to be resized to negative widths

### DIFF
--- a/src/clique_table.erl
+++ b/src/clique_table.erl
@@ -91,7 +91,9 @@ resize_row(MaxLength, Widths) ->
     Sum = lists:sum(Widths),
     case Sum > MaxLength of
 	true ->
-	    resize_items(Sum, MaxLength, Widths);
+	    NewWidths = resize_items(Sum, MaxLength, Widths),
+	    % go around again, just in case some columns were unshrinkable
+	    resize_row(MaxLength, NewWidths);
 	false ->
 	    Widths
     end.
@@ -121,7 +123,13 @@ reduce_widths(PerColumn, Total, Widths) ->
 				{0, [Width | NewWidths]};
 			    _ ->
 				Rem = Remaining - PerColumn,
-				{Rem, [Width - PerColumn | NewWidths]}
+				%% don't allow negative column widths
+				NewWidth = case Width - PerColumn of
+				               Int when Int < 0 ->
+				                   Width;
+				               X -> X
+				           end,
+				{Rem, [NewWidth | NewWidths]}
 			end
 		    end, {Total, []}, Widths),
     NewWidths.


### PR DESCRIPTION
On master, with a 100 column terminal:

``` erlang
8> Header = [<<"Test">>, <<"Result">>, <<"Reason">>, <<"Test Duration">>].
[<<"Test">>,<<"Result">>,<<"Reason">>,<<"Test Duration">>]
9> Rows = [["end_to_end","pass","N/A",11543062],
9>                   ["simple","pass","N/A",6228040],
9>                   ["roam",fail,
9>                    ["proplists : get_value ( channel , MStatus2 )",32,61,32,
9>                     "12",32,105,115,32,110,111,116,32,101,113,117,97,108,32,
9>                     116,111,32,101,120,112,101,99,116,101,100,32,118,97,108,
9>                     117,101,32,"13",32,97,116,32,108,105,110,101,32,"45"],
9>                    34919569]]
9> .
[["end_to_end","pass","N/A",11543062],
 ["simple","pass","N/A",6228040],
 ["roam",fail,
  ["proplists : get_value ( channel , MStatus2 )",32,61,32,
   "12",32,105,115,32,110,111,116,32,101,113,117,97,108,32,116,
   111,32,101|...],
  34919569]]
10> clique_table:autosize_create_table(Header, Rows).
** exception error: no function clause matching lists:seq(1,-2) (lists.erl, line 228)
     in function  clique_table:char_seq/2 (src/clique_table.erl, line 196)
     in call from clique_table:'-vertical_border/1-lc$^0/1-0-'/1 (src/clique_table.erl, line 191)
     in call from clique_table:'-vertical_border/1-lc$^0/1-0-'/1 (src/clique_table.erl, line 192)
     in call from clique_table:vertical_border/1 (src/clique_table.erl, line 191)
     in call from clique_table:create_table/4 (src/clique_table.erl, line 71)
```

This branch prevents column widths ever going negative, although the results may not be ideal.
