### PR TITLE
Fix regression that broke --help and --format

### DIFF
--- a/src/clique_parser.erl
+++ b/src/clique_parser.erl
@@ -122,7 +122,7 @@ parse_flags([Val | _T], [], _Acc) ->
 
 %% TODO: If this gets more complicated, write out a function to extract
 %% the flag names from ?GFLAG_SPECS instead of hand-coding it in ?GLOBAL_FLAGS
--define(GLOBAL_FLAGS, [$h, help, format]).
+-define(GLOBAL_FLAGS, [$h, "help", "format"]).
 -define(GFLAG_SPECS, [clique_spec:make({help, [{shortname, "h"},
                                                {longname, "help"}]}),
                       clique_spec:make({format, [{longname, "format"}]})]).


### PR DESCRIPTION
When changing from atoms to strings for flag specs, this one line of code was missed, causing extract_global_flags to not recognize global flags. Since they were being left as non-global, they'd get passed through, and then the command would fail since the flags weren't defined in the command spec.
