### PR TITLE
The column widths are reversed at the end of the fold

### DIFF
--- a/src/clique_table.erl
+++ b/src/clique_table.erl
@@ -124,7 +124,7 @@ reduce_widths(PerColumn, Total, Widths) ->
 				{Rem, [Width - PerColumn | NewWidths]}
 			end
 		    end, {Total, []}, Widths),
-    NewWidths.
+    lists:reverse(NewWidths).
 
 get_row_length(Spec, Rows) ->
     Res = lists:foldl(fun({_Name, MinSize}, Total) ->


### PR DESCRIPTION
Old result:

```
+-------------+----------------------------------------------------------------------------------------------+------+---------+
|    Test     |                                            Result                                            |Reason|Test Dura|
+-------------+----------------------------------------------------------------------------------------------+------+---------+
| end_to_end  |                                             pass                                             | N/A  |11543062 |
|   simple    |                                             pass                                             | N/A  | 6228040 |
|    roam     |                                             fail                                             |propli|34919569 |
+-------------+----------------------------------------------------------------------------------------------+------+---------+
```

New result:

```
+---------+------+----------------------------------------------------------------------------------------------+-------------+
|  Test   |Result|                                            Reason                                            |Test Duration|
+---------+------+----------------------------------------------------------------------------------------------+-------------+
|end_to_en| pass |                                             N/A                                              |  11543062   |
| simple  | pass |                                             N/A                                              |   6228040   |
|  roam   | fail |proplists : get_value ( channel , MStatus2 ) = 12 is not equal to expected value 13 at line 45|  34919569   |
+---------+------+----------------------------------------------------------------------------------------------+-------------+
```
