### PR TITLE
Fix type specs for usage registration.

### DIFF
--- a/src/clique.erl
+++ b/src/clique.erl
@@ -76,7 +76,7 @@ register_command(Cmd, Keys, Flags, Fun) ->
 
 %% @doc Register usage for a given command sequence. Lookups are by longest
 %% match.
--spec register_usage([string()], iolist()) -> true.
+-spec register_usage([string()], clique_usage:usage()) -> true.
 register_usage(Cmd, Usage) ->
     clique_usage:register(Cmd, Usage).
 

--- a/src/clique_usage.erl
+++ b/src/clique_usage.erl
@@ -29,6 +29,9 @@
 
 -type err() :: {error, term()}.
 -type usage_function() :: fun(() -> iolist()).
+-type usage() :: iolist() | usage_function().
+
+-export_type([usage/0]).
 
 %% API
 -export([init/0,
@@ -42,7 +45,7 @@ init() ->
 
 %% @doc Register usage for a given command sequence. Lookups are by longest
 %% match.
--spec register([string()], iolist() | usage_function()) -> true.
+-spec register([string()], usage()) -> true.
 register(Cmd, Usage) ->
     ets:insert(?usage_table, {Cmd, Usage}).
 


### PR DESCRIPTION
This was missed when the function form of usage was created, resulting
in the 'clique' module having a narrower spec than the 'clique_usage'
module. Prompted by basho/riak_repl#660 (RIAK-1307) (RIAK-1308).
