### PR TITLE
Allow the user to specify wildcards when registering command specs

### DIFF
--- a/src/clique.erl
+++ b/src/clique.erl
@@ -69,8 +69,8 @@ register_writer(Name, Module) ->
 register_config_whitelist(SettableKeys) ->
     clique_config:whitelist(SettableKeys).
 
-%% @doc Register a cli command (i.e.: "riak-admin handoff status")
--spec register_command([string()], list(), list(), fun()) -> true.
+%% @doc Register a cli command (e.g.: "riak-admin handoff status", or "riak-admin cluster join '*'")
+-spec register_command(['*' | string()], list(), list(), fun()) -> true.
 register_command(Cmd, Keys, Flags, Fun) ->
     clique_command:register(Cmd, Keys, Flags, Fun).
 

--- a/src/clique.erl
+++ b/src/clique.erl
@@ -70,7 +70,7 @@ register_config_whitelist(SettableKeys) ->
     clique_config:whitelist(SettableKeys).
 
 %% @doc Register a cli command (e.g.: "riak-admin handoff status", or "riak-admin cluster join '*'")
--spec register_command(['*' | string()], list(), list(), fun()) -> true.
+-spec register_command(['*' | string()], list(), list(), fun()) -> ok | {error, atom()}.
 register_command(Cmd, Keys, Flags, Fun) ->
     clique_command:register(Cmd, Keys, Flags, Fun).
 

--- a/src/clique_command.erl
+++ b/src/clique_command.erl
@@ -47,16 +47,16 @@ register(Cmd, Keys0, Flags0, Fun) ->
     ets:insert(?cmd_table, {Cmd, Keys, Flags, Fun}).
 
 -spec run(err()) -> err();
-         ({fun(), proplist(), proplist()})-> status().
+         ({fun(), [string()], proplist(), proplist()})-> status().
 run({error, _}=E) ->
     E;
-run({Fun, Args, Flags, GlobalFlags}) ->
+run({Fun, Cmd, Args, Flags, GlobalFlags}) ->
     Format = proplists:get_value(format, GlobalFlags, "human"),
     case proplists:is_defined(help, GlobalFlags) of
         true ->
             {usage, Format};
         false ->
-            Result = Fun(Args, Flags),
+            Result = Fun(Cmd, Args, Flags),
             {Result, Format}
     end.
 

--- a/src/clique_parser.erl
+++ b/src/clique_parser.erl
@@ -388,19 +388,21 @@ parse_valueless_flags_test() ->
 
 validate_valid_short_flag_test() ->
     Spec = spec(),
+    Cmd = element(1, Spec),
     Args = [],
     Node = "dev2@127.0.0.1",
     Flags = [{$n, Node}, {$f, undefined}],
-    {undefined, [], ConvertedFlags, []} = validate({Spec, Args, Flags, []}),
+    {undefined, Cmd, [], ConvertedFlags, []} = validate({Spec, Args, Flags, []}),
     ?assert(lists:member({node, 'dev2@127.0.0.1'}, ConvertedFlags)),
     ?assert(lists:member({force, undefined}, ConvertedFlags)).
 
 validate_valid_long_flag_test() ->
     Spec = spec(),
+    Cmd = element(1, Spec),
     Args = [],
     Node = "dev2@127.0.0.1",
     Flags = [{"node", Node}, {"force", undefined}],
-    {undefined, [], ConvertedFlags, []} = validate({Spec, Args, Flags, []}),
+    {undefined, Cmd, [], ConvertedFlags, []} = validate({Spec, Args, Flags, []}),
     ?assert(lists:member({node, 'dev2@127.0.0.1'}, ConvertedFlags)),
     ?assert(lists:member({force, undefined}, ConvertedFlags)).
 
@@ -415,8 +417,9 @@ validate_invalid_flags_test() ->
 
 validate_valid_args_test() ->
     Spec = spec(),
+    Cmd = element(1, Spec),
     Args = [{"sample_size", "5"}],
-    {undefined, ConvertedArgs, [], []} = validate({Spec, Args, [], []}),
+    {undefined, Cmd, ConvertedArgs, [], []} = validate({Spec, Args, [], []}),
     ?assertEqual(ConvertedArgs, [{sample_size, 5}]).
 
 validate_invalid_args_test() ->
@@ -427,8 +430,9 @@ validate_invalid_args_test() ->
 
 arg_datatype_test() ->
     Spec = dt_validate_spec(),
+    Cmd = element(1, Spec),
     ValidArg = [{"sample_size", "10"}],
-    {undefined, ConvertedArgs, [], []} = validate({Spec, ValidArg, [], []}),
+    {undefined, Cmd, ConvertedArgs, [], []} = validate({Spec, ValidArg, [], []}),
     ?assertEqual(ConvertedArgs, [{sample_size, 10}]),
 
     InvalidTypeArg = [{"sample_size", "A"}],
@@ -441,8 +445,9 @@ arg_validation_test() ->
 
 flag_datatype_test() ->
     Spec = dt_validate_spec(),
+    Cmd = element(1, Spec),
     ValidFlag = [{$n, "a@dev1"}],
-    {undefined, _, Flags, []} = validate({Spec, [], ValidFlag, []}),
+    {undefined, Cmd, [], Flags, []} = validate({Spec, [], ValidFlag, []}),
     ?assertEqual([{node, 'a@dev1'}], Flags),
 
     InvalidFlag = [{"node", "someothernode@foo.bar"}],

--- a/src/clique_parser.erl
+++ b/src/clique_parser.erl
@@ -141,11 +141,11 @@ extract_global_flags({Spec, Args, Flags0}) ->
 
 -spec validate(err()) -> err();
               ({tuple(), args(), flags(), flags()}) ->
-                      err() | {fun(), proplist(), proplist(), flags()}.
+                      err() | {fun(), [string()], proplist(), proplist(), flags()}.
 validate({error, _}=E) ->
     E;
 validate({Spec, Args0, Flags0, GlobalFlags}) ->
-    {_Cmd, KeySpecs, FlagSpecs, Callback} = Spec,
+    {Cmd, KeySpecs, FlagSpecs, Callback} = Spec,
     case validate_args(KeySpecs, Args0) of
         {error, _}=E ->
             E;
@@ -154,7 +154,7 @@ validate({Spec, Args0, Flags0, GlobalFlags}) ->
                 {error, _}=E ->
                     E;
                 Flags ->
-                    {Callback, Args, Flags, GlobalFlags}
+                    {Callback, Cmd, Args, Flags, GlobalFlags}
             end
     end.
 


### PR DESCRIPTION
This PR contains new code that allow commands to have freeform wildcard fields, which must appear after the command base, but before any flags or key/value pairs. For example, we could reimplement "riak-admin cluster join <node>" using this new functionality by registering a ["riak-admin", "cluster", "join", '*'] command specification.

Prior to these changes, the only args that were passed into the command callbacks were two lists: flags and k/v options. With this PR, we add a third argument to the beginning of the arg list for the callback, which contains the actual strings the user entered for the command. For instance, continuing with the example above, we could implement a callback that looks like this:

``` erlang
cluster_join(["riak-admin", "cluster", "join", NodeName], KeyList, FlagList) ->
    ...
```

This does, unfortunately, break compatibility with existing command callbacks, since they expect two arguments, not three. But any existing commands can just add `_,` to the beginnings of their callbacks, since the actual input strings are only interesting when you're using wildcards (or perhaps if you want to overload the same callback for multiple different commands, but that's not anything that would've really been possible prior to these changes, so it's a moot point for backward compatibility). I couldn't really come up with a better way than this, unless we want to do something ugly like run erlang:fun_info and check if the callback takes two or three arguments at callback time, and since we're still pre-1.0, it seems like it shouldn't be a huge deal to break compatibility in a small way.
