### PR TITLE
Add keyspec wildcard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,13 @@ to the callback. If a command is registered without wildcards, the the same comm
 be passed to the callback function, and so that particular argument can be ignored (as it was
 in the example above).
 
+#### Wildcard Keyspecs
+Specifying keyspecs for a command has the advantage of doing type conversions and automatically
+recognizing if particular keys are valid or not. However, in some cases users may wish to allow
+any and all key/value pairs through to the callback. To achieve this, an '_' atom can be used
+as a keyspec, and all key=value pairs will be passed to the command callback in a list of type
+`[{string(), string()}]`.
+
 ### register_usage/2
 We want to show usage explicitly in many cases, and not with the `--help` flag.
 To make this easier, the user must explicitly register usage points. If one of

--- a/src/clique.erl
+++ b/src/clique.erl
@@ -70,7 +70,7 @@ register_config_whitelist(SettableKeys) ->
     clique_config:whitelist(SettableKeys).
 
 %% @doc Register a cli command (e.g.: "riak-admin handoff status", or "riak-admin cluster join '*'")
--spec register_command(['*' | string()], list(), list(), fun()) -> ok | {error, atom()}.
+-spec register_command(['*' | string()], '_' | list(), list(), fun()) -> ok | {error, atom()}.
 register_command(Cmd, Keys, Flags, Fun) ->
     clique_command:register(Cmd, Keys, Flags, Fun).
 

--- a/src/clique_command.erl
+++ b/src/clique_command.erl
@@ -40,11 +40,14 @@ init() ->
     ok.
 
 %% @doc Register a cli command (i.e.: "riak-admin handoff status")
--spec register(['*' | string()], list(), list(), fun()) -> ok | {error, atom()}.
+-spec register(['*' | string()], '_' | list(), list(), fun()) -> ok | {error, atom()}.
 register(Cmd, Keys0, Flags0, Fun) ->
     case verify_register(Cmd) of
         ok ->
-            Keys = make_specs(Keys0),
+            Keys = case Keys0 of
+                       '_' -> '_';
+                       _ -> make_specs(Keys0)
+                   end,
             Flags = make_specs(Flags0),
             ets:insert(?cmd_table, {Cmd, Keys, Flags, Fun}),
             ok;


### PR DESCRIPTION
This PR allows you to specify '_' in the place of a normal keyspec when registering a command, and all key/value pairs will be passed into the command callback as a list of type `[{string(), string()}]`
