### PR TITLE
Fixed show, set command arguments.

### DIFF
--- a/src/clique_command.erl
+++ b/src/clique_command.erl
@@ -33,7 +33,10 @@
 -type proplist() :: [{atom(), term()}].
 -type status() :: clique_status:status().
 
--define(SET_CMD_SPEC, {["_", "set"], '_', clique_config:config_flags(), fun clique_config:set/2}).
+-define(SET_CMD_SPEC, {["_", "set"], '_', clique_config:config_flags(),
+                       fun (_, Args, Flags) ->
+                               clique_config:set(Args, Flags)
+                       end}).
 
 init() ->
     _ = ets:new(?cmd_table, [public, named_table]),

--- a/src/clique_command.erl
+++ b/src/clique_command.erl
@@ -34,8 +34,8 @@
 -type status() :: clique_status:status().
 
 -define(SET_CMD_SPEC, {["_", "set"], '_', clique_config:config_flags(),
-                       fun (_, Args, Flags) ->
-                               clique_config:set(Args, Flags)
+                       fun (_, SetArgs, SetFlags) ->
+                               clique_config:set(SetArgs, SetFlags)
                        end}).
 
 init() ->

--- a/src/clique_command.erl
+++ b/src/clique_command.erl
@@ -151,5 +151,5 @@ make_specs(Specs) ->
 cmd_spec(Cmd, CmdFun, AllowedFlags) ->
     [_Script, _CmdName | CfgKeys] = Cmd,
     %% Discard key/val args passed in since we don't need them, and inject the freeform args:
-    SpecFun = fun([], Flags) -> CmdFun(CfgKeys, Flags) end,
+    SpecFun = fun(_, [], Flags) -> CmdFun(CfgKeys, Flags) end,
     {Cmd, [], AllowedFlags, SpecFun}.


### PR DESCRIPTION
From what I can tell: show, set, describe - the clique internal arguments get a special treatment as they behave differently then other commands. `cmd_spec` is use to generate a wrapper to prevent some of the processing to be done on the arguments.

The returned function had the arity of `2` however `clique_command:run` expects a function with the arity of `3`. The patch returns a function of the arity of `3` by simply ignoring the first argument.
