### PR TITLE
Enable custom return status codes

### DIFF
--- a/src/clique.erl
+++ b/src/clique.erl
@@ -137,7 +137,7 @@ basic_cmd_test() ->
     Callback = fun(CallbackCmd, [], []) ->
                        ?assertEqual(Cmd, CallbackCmd),
                        put(pass_basic_cmd_test, true),
-                       [] %% Need to return a valid tatus, but don't care what's in it
+                       [] %% Need to return a valid status, but don't care what's in it
                end,
     ?assertEqual(ok, register_command(Cmd, [], [], Callback)),
     ?assertEqual(ok, run(Cmd)),

--- a/src/clique.erl
+++ b/src/clique.erl
@@ -143,4 +143,11 @@ basic_cmd_test() ->
     ?assertEqual(ok, run(Cmd)),
     ?assertEqual(true, get(pass_basic_cmd_test)).
 
+cmd_error_status_test() ->
+    clique_manager:start_link(), %% May already be started from a different test, which is fine.
+    Cmd = ["clique-test", "cmd_error_status_test"],
+    Callback = fun(_, [], []) -> {exit_status, 123, []} end,
+    ?assertEqual(ok, register_command(Cmd, [], [], Callback)),
+    ?assertEqual({error, 123}, run(Cmd)).
+
 -endif.

--- a/src/clique.erl
+++ b/src/clique.erl
@@ -81,8 +81,9 @@ register_usage(Cmd, Usage) ->
     clique_usage:register(Cmd, Usage).
 
 %% @doc Take a list of status types and generate console output
--spec print(err() | clique_status:status() | {clique_status:status(), integer(), string()},
-            [string()]) -> ok.
+-spec print({error, term()}, term()) -> {error, 1};
+           ({clique_status:status(), integer(), string()}, [string()]) -> ok | {error, integer()};
+           (clique_status:status(), [string()]) -> ok.
 print({error, _} = E, Cmd) ->
     print(E, Cmd, "human"),
     {error, 1};

--- a/src/clique.erl
+++ b/src/clique.erl
@@ -19,6 +19,10 @@
 %% -------------------------------------------------------------------
 -module(clique).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 %% API
 -export([register/1,
          register_node_finder/1,
@@ -124,3 +128,19 @@ run(Cmd) ->
     M2 = clique_parser:extract_global_flags(M1),
     M3 = clique_parser:validate(M2),
     print(clique_command:run(M3), Cmd).
+
+-ifdef(TEST).
+
+basic_cmd_test() ->
+    clique_manager:start_link(), %% May already be started from a different test, which is fine.
+    Cmd = ["clique-test", "basic_cmd_test"],
+    Callback = fun(CallbackCmd, [], []) ->
+                       ?assertEqual(Cmd, CallbackCmd),
+                       put(pass_basic_cmd_test, true),
+                       [] %% Need to return a valid tatus, but don't care what's in it
+               end,
+    ?assertEqual(ok, register_command(Cmd, [], [], Callback)),
+    ?assertEqual(ok, run(Cmd)),
+    ?assertEqual(true, get(pass_basic_cmd_test)).
+
+-endif.

--- a/src/clique.erl
+++ b/src/clique.erl
@@ -108,7 +108,7 @@ print(Status, _Cmd, Format) ->
     io:format(RemoteStderr, "~ts", [Stderr]).
 
 %% @doc Run a config operation or command
--spec run([string()]) -> ok | {error, term()}.
+-spec run([string()]) -> ok.
 run(Cmd) ->
     M0 = clique_command:match(Cmd),
     M1 = clique_parser:parse(M0),

--- a/src/clique_command.erl
+++ b/src/clique_command.erl
@@ -87,6 +87,8 @@ run({Fun, Cmd, Args, Flags, GlobalFlags}) ->
             case Fun(Cmd, Args, Flags) of
                 {exit_status, ExitStatus, Result} ->
                     {Result, ExitStatus, Format};
+                Error = {error, _} ->
+                    {Error, 1, Format};
                 Result ->
                     {Result, 0, Format}
             end

--- a/src/clique_command.erl
+++ b/src/clique_command.erl
@@ -85,7 +85,7 @@ run({Fun, Cmd, Args, Flags, GlobalFlags}) ->
             {usage, 0, Format};
         false ->
             case Fun(Cmd, Args, Flags) of
-                {Result, ExitStatus} ->
+                {exit_status, ExitStatus, Result} ->
                     {Result, ExitStatus, Format};
                 Result ->
                     {Result, 0, Format}

--- a/src/clique_command.erl
+++ b/src/clique_command.erl
@@ -75,17 +75,21 @@ verify_register(Cmd) ->
 
 -spec run(err()) -> err();
          ({fun(), [string()], clique_parser:args(), clique_parser:flags(),
-               clique_parser:flags()}) -> {usage | status(), string()}.
+               clique_parser:flags()}) -> {usage | status(), integer(), string()}.
 run({error, _}=E) ->
     E;
 run({Fun, Cmd, Args, Flags, GlobalFlags}) ->
     Format = proplists:get_value(format, GlobalFlags, "human"),
     case proplists:is_defined(help, GlobalFlags) of
         true ->
-            {usage, Format};
+            {usage, 0, Format};
         false ->
-            Result = Fun(Cmd, Args, Flags),
-            {Result, Format}
+            case Fun(Cmd, Args, Flags) of
+                {Result, ExitStatus} ->
+                    {Result, ExitStatus, Format};
+                Result ->
+                    {Result, 0, Format}
+            end
     end.
 
 -spec match([list()])-> {tuple(), list()} | {error, no_matching_spec}.

--- a/src/clique_command.erl
+++ b/src/clique_command.erl
@@ -75,7 +75,7 @@ verify_register(Cmd) ->
 
 -spec run(err()) -> err();
          ({fun(), [string()], clique_parser:args(), clique_parser:flags(),
-               clique_parser:flags()}) -> {usage | status(), integer(), string()}.
+               clique_parser:flags()}) -> {usage | {error, term()} | status(), integer(), string()}.
 run({error, _}=E) ->
     E;
 run({Fun, Cmd, Args, Flags, GlobalFlags}) ->

--- a/src/clique_command.erl
+++ b/src/clique_command.erl
@@ -74,7 +74,8 @@ verify_register(Cmd) ->
     end.
 
 -spec run(err()) -> err();
-         ({fun(), [string()], proplist(), proplist()})-> status().
+         ({fun(), [string()], clique_parser:args(), clique_parser:flags(),
+               clique_parser:flags()}) -> {usage | status(), string()}.
 run({error, _}=E) ->
     E;
 run({Fun, Cmd, Args, Flags, GlobalFlags}) ->


### PR DESCRIPTION
This PR allows callbacks to specify custom status codes to be returned as a result of a Clique command being run.

These changes also allow existing callbacks to remain the same - triggering them will cause clique:run to just return 'ok' as before. Callbacks can now also specify custom exit status by returning {exit_status, Status, Result} instead of just Result, which will cause clique:run to return {error, ExitStatus} instead. Finally, internal Clique errors will (for now) default to returning an error code of 1.

This is technically a slight API change, insofar as that it is now possible for clique:run to return {error, StatusCode} as well as 'ok'. However, none of our existing code has a problem with this, so this would only potentially affect third-party code outside of Basho. For anyone who doesn't care about return codes, it's a very simple change to work around, and for someone who _does_ care about return codes, this should be a welcome enhancement.
