### PR TITLE
Update dependencies on develop branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,5 @@
 ]}.
 
 {deps, [
-  {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
+  {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.5"}}}
 ]}.


### PR DESCRIPTION
Treat cuttlefish as an external dependency and declare dependency on latest tag (`2.0.5`).
