### PR TITLE
Modify and improve config change callback system

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,19 +170,27 @@ exceed the new limit.
 Configuration specific behaviour can be managed by registering a callback to
 fire when a given configuration variable is set on the cli. The callback runs
 *after* the corresponding environment variables are set. The callback function
-is a 3-arity function that gets called with the original key (as a list of
-strings()), the untranslated value to set (as a string()) and the flags passed
-on the command-line. The flags can be either '--all' to run on all nodes, or
---node N to run on node N. If no flags are given the command should be executed
-on the local node (where the cli command was run) only.
+is a 2-arity function that gets called with the original key (as a list of
+strings()), and the untranslated value to set (as a string()).
+
+On the command-line, the flags can be either '--all' to run on all nodes, or
+--node N to run on node N instead of the local node. If no flags are given,
+the config change will take place on the local node (where the cli command was
+run) only. These flags are not visible to the callback function; rather, the
+callback function will be called on whichever nodes the config change is being
+made.
+
+Unlike command callbacks, config callbacks need only return a short string
+describing any immediate results of the config change that may have taken
+place. This allows results from --all to be compiled into a table, and lets
+results from other invocations be displayed via simple status messages.
 
 ```erlang
--spec set_transfer_limit(Key :: [string()], Val :: string(),
-                         Flags :: [{atom(), proplist()}]).
+-spec set_transfer_limit(Key :: [string()], Val :: string()) -> Result :: string().
 ...
 
 Key = ["transfer_limit"],
-Callback = fun set_transfer_limit/3,
+Callback = fun set_transfer_limit/2,
 clique:register_config(Key, Callback).
 ```
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ run) only. These flags are not visible to the callback function; rather, the
 callback function will be called on whichever nodes the config change is being
 made.
 
-Unlike command callbacks, config callbacks need only return a short string
+Unlike command callbacks, config callbacks need only return a short iolist
 describing any immediate results of the config change that may have taken
 place. This allows results from --all to be compiled into a table, and lets
 results from other invocations be displayed via simple status messages.

--- a/src/clique_config.erl
+++ b/src/clique_config.erl
@@ -262,15 +262,7 @@ get_remote_env_status(EnvKeys, CuttlefishFlags) ->
 run_callback({error, _}=E) ->
     E;
 run_callback(Args) ->
-    KVFuns = lists:foldl(fun({K, V}, Acc) ->
-                             case ets:lookup(?config_table, K) of
-                                 [{K, F}] ->
-                                     [{K, V, F} | Acc];
-                                 [] ->
-                                     Acc
-                             end
-                         end, [], Args),
-    OutStrings = [run_callback(K, V, F) || {K, V, F} <- KVFuns],
+    OutStrings = [run_callback(K, V, F) || {K, V} <- Args, {_, F} <- ets:lookup(?config_table, K)],
     Output = string:join(OutStrings, "\n"), %% TODO return multiple strings tagged with keys
     %% Tag the return value with our current node so we know
     %% where this result came from when we use multicall:

--- a/src/clique_error.erl
+++ b/src/clique_error.erl
@@ -20,7 +20,8 @@
 -module(clique_error).
 
 %% API
--export([format/2]).
+-export([format/2,
+         badrpc_to_error/2]).
 
 -type status() :: clique_status:status().
 -type err() :: {error, term()}.
@@ -82,10 +83,19 @@ format(_Cmd, {error, {nodedown, Node}}) ->
     status(io_lib:format("Target node is down: ~p~n", [Node]));
 format(_Cmd, {error, bad_node}) ->
     status("Invalid node name");
+format(_Cmd, {error, {{badrpc, Reason}, Node}}) ->
+    status(io_lib:format("RPC to node ~p failed for reason: ~p~n", [Node, Reason]));
 format(_Cmd, {error, {conversion, _}}=TypeError) ->
     %% Type-conversion error originating in cuttlefish
     status(cuttlefish_error:xlate(TypeError)).
 
+-spec badrpc_to_error(string() | node(), term()) -> err().
+badrpc_to_error(Node, nodedown) ->
+    {error, {nodedown, Node}};
+badrpc_to_error(Node, rpc_process_down) ->
+    {error, {rpc_process_down, Node}};
+badrpc_to_error(Node, Reason) ->
+    {error, {{badrpc, Reason}, Node}}.
 
 -spec status(string()) -> status().
 status(Str) ->

--- a/src/clique_nodes.erl
+++ b/src/clique_nodes.erl
@@ -24,6 +24,10 @@
          nodes/0,
          register/1]).
 
+-ifdef(TEST).
+-export([teardown/0]).
+-endif.
+
 -define(nodes_table, clique_nodes).
 
 init() ->
@@ -53,3 +57,7 @@ safe_rpc(Node, Module, Function, Args) ->
             {badrpc, rpc_process_down}
     end.
 
+-ifdef(TEST).
+teardown() ->
+    ets:delete(?nodes_table).
+-endif.


### PR DESCRIPTION
These changes break backwards compatibility with the old config callback API, but the new system is much easier to use in that it automatically deals with use of the --node and --all flags and calls the callbacks in the correct places. It also allows the callbacks to add output messages that can be displayed back to the user. In the case of the --all flag, all the results will now be displayed back to the user in a table.

This PR also updates the documentation appropriately, and adds extensive unit tests for the clique "set" command.
