### PR TITLE
Don't throw error on empy argument

### DIFF
--- a/src/clique_error.erl
+++ b/src/clique_error.erl
@@ -58,6 +58,8 @@ format(_Cmd, {error, {invalid_flags, Flags}}) ->
     status(io_lib:format("Invalid Flags: ~p", [Flags]));
 format(_Cmd, {error, {invalid_flag_value, {Name, Val}}}) ->
     status(io_lib:format("Invalid value: ~p for flag: ~p", [Val, Name]));
+format(_Cmd, {error, {invalid_kv_arg, Arg}}) ->
+    status(io_lib:format("Empty value in argument: ~p", [Arg]));
 format(_Cmd, {error, {invalid_flag_combination, Msg}}) ->
     status(io_lib:format("Error: ~ts", [Msg]));
 format(_Cmd, {error, {invalid_value, Val}}) ->

--- a/src/clique_parser.erl
+++ b/src/clique_parser.erl
@@ -380,7 +380,7 @@ parse_valid_arg_value_with_equal_sign_test() ->
 %% All arguments must be of type k=v
 parse_invalid_kv_arg_test() ->
     Spec = spec(),
-    Args = ["ayo"],
+    Args = ["ayo="],
     ?assertMatch({error, _}, parse({Spec, Args})).
 
 %% This succeeds, because we aren't validating the flag, just parsing

--- a/src/clique_parser.erl
+++ b/src/clique_parser.erl
@@ -380,8 +380,13 @@ parse_valid_arg_value_with_equal_sign_test() ->
 %% All arguments must be of type k=v
 parse_invalid_kv_arg_test() ->
     Spec = spec(),
-    Args = ["ayo="],
-    ?assertMatch({error, _}, parse({Spec, Args})).
+    %% Argument with equal sign and no value
+    ArgsNoVal = ["ayo="],
+    ?assertMatch({error, {invalid_kv_arg, _}}, parse({Spec, ArgsNoVal})),
+    %% Argument without equal sign and no value
+    ArgsNoEqualAndNoVal = ["ayo"],
+    ?assertMatch({error, {invalid_kv_arg, _}}, parse({Spec, ArgsNoEqualAndNoVal})).
+
 
 %% This succeeds, because we aren't validating the flag, just parsing
 %% Note: Short flags get parsed into tuples with their character as first elem


### PR DESCRIPTION
Fixes #89 

Shows a clique status message instead of throwing an error and stack-trace when an Argument value is empty (For example a user running `$ my-cli command foo=`). 